### PR TITLE
Trigger backtrace on SIGABRT to support Darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backtrace-on-stack-overflow"
 description = "Best effort backtrace printing"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/matklad/backtrace-on-stack-overflow"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub unsafe fn enable() {
             signal::SigSet::empty(),
         );
         signal::sigaction(signal::SIGSEGV, &sig_action).unwrap();
+        signal::sigaction(signal::SIGABRT, &sig_action).unwrap();
     })
 }
 


### PR DESCRIPTION
On my Mac (x86_64 Monterey 12.5.1) this crate does not work as is, because the signal triggered when the stack overflows is SIGABRT, not SIGSEGV. This commit fixes the issue and hopefully makes the crate just a little bit more portable by handling both signals.

@matklad I kind of like this broad net approach for something like this, but we could try to be more precise by using `#[cfg(target = ... )]` macros to _only_ catch `SIGABRT` on MacOS and `SIGSEGV` on Linux. Let me know if you prefer that.