### PR TITLE
add truncation and exit program

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,14 @@
+fn main() {
+    unsafe {
+        backtrace_on_stack_overflow::enable_with_limit(20);
+    }
+
+    f(1)
+}
+
+fn f(x: u64) {
+    if x == 0 {
+        return;
+    }
+    f(x)
+}


### PR DESCRIPTION
My machine hangs printing the infinite stack in infinite SIGABRT callbacks

- Changing `abort` to `exit` to kill the program after printing the trace once 
- Set the default limit for number of frames to print to 10
- `enable_with_limit` to change the limit

Testing: cargo run --example main
