### PR TITLE
Update nix to 0.31.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ exclude = [".github/", "bors.toml", "rustfmt.toml"]
 [dependencies]
 backtrace = "0.3.65"
 libc = "0.2.126"
-nix = "0.26.4"
+nix = { version = "0.31.1", features = ["signal"] }


### PR DESCRIPTION
This fixes build failures on loongarch64 because nix only started supporting it in version 0.27.0. I've tested this change on a LoongArch machine and it works perfectly.

Since there hasn't been a release in about three years, could you please consider releasing a new version so downstream projects can pick up this fix? Thanks!